### PR TITLE
Corrected setCol() to setColumn()

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -22,7 +22,7 @@ The API commands are, in no particular order:
 - @clear()@ := clears the matrix completely†
 - @setPixel(uint8_t row, uint8_t col, uint8_t onoff)@ := sets the state of a single pixel. @onoff@ should be either 0 (off) or 1 (on)†
 - @setRow(uint8_t row, uint16_t value)@ := sets the content of an entire row (16 bits)†
-- @setCol(uint8_t col, uint8_t value)@ := sets the content of an entire column (8 bits)†
+- @setColumn(uint8_t col, uint8_t value)@ := sets the content of an entire column (8 bits)†
 - @drawSprite16(Sprite16 data)@ := draws the @Sprite16@ onto the matrix at point (0, 0) (see below)†
 - @drawSprite16(Sprite16 data, uint8_t x, uint8_t y)@ := as above, but at point (x, y)†
 - @write()@ := writes the display buffer to the IC (updates the display)


### PR DESCRIPTION
Actual API is setColumn while it was documented as setCol.